### PR TITLE
Update canvas-linter-action to v1.1.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - name: Canvas Lint
-        uses: easolhq/canvas-linter-action@v1.0.3
+        uses: easolhq/canvas-linter-action@v1.1.0


### PR DESCRIPTION
Updates to https://github.com/easolhq/canvas-linter-action/releases/tag/v1.1.0

Build failure is addressed via #2 